### PR TITLE
Feature job post modal fixes

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -95,7 +95,6 @@ body {
 
 .job-description {
     color: #555;
-    width: 300px;
 }
 
 .modal {
@@ -128,7 +127,8 @@ body {
     text-align: left;
 }
 
-.modal-content form input {
+.modal-content form input,
+.modal-content form textarea {
     display: block;
     margin-bottom: 10px;
     margin-left: 5px;

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -159,11 +159,12 @@ currencyField.addEventListener('focus', () => {
 }); 
 
 currencyField.addEventListener('blur', () => {
+  if (currencyField.value !== '') {
   const amount = parseFloat(currencyField.value);
   const formattedCurrency = formatCurrency(amount); 
   currencyField.type = 'text';
   currencyField.value = formattedCurrency;
-});
+}});
 
 function formatCurrency(amount) {
   const formatter = new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP' });

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -101,14 +101,14 @@
             required=""
           />
           <label for="jobDescription">Job Description:</label>
-          <input
+          <textarea
             class="job-description"
-            type="text"
             id="jobDescription"
             name="Description"
             placeholder="Enter details of role here"
             required=""
-          />
+            cols="25"
+          /></textarea>
           <label for="jobSalary">Salary:</label>
           <input
             type="text"

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -126,47 +126,6 @@
       </div>
     </div>
 
-    <!-- PostJob modal HTML here -->
-
-    <div id="jobPostModal" class="modal">
-      <div class="modal-content">
-        <span class="close" onclick="closeJobPostModal()">×</span>
-        <h2>Create New Job Post:</h2>
-        <form id="jobPostForm">
-          <label for="jobTitle">Job Title:</label>
-          <input
-            type="text"
-            id="jobTitle"
-            name="jobTitle"
-            placeholder="Trapeze Artist, etc."
-            required=""
-          />
-          <label for="jobDescription">Job Description:</label>
-          <input
-            class="job-description"
-            type="text"
-            id="jobDescription"
-            name="Description"
-            placeholder="Enter details of role here"
-            required=""
-          />
-          <label for="jobSalary">Salary:</label>
-          <input
-            type="text"
-            id="jobSalary"
-            name="jobSalary"
-            pattern="^\£\d{1,3}(,\d{3})*(\.\d+)?$"
-            placeholder="Enter Amount"
-            required=""
-          />
-          <div class="button-container">
-            <button type="submit" class="button">Submit</button>
-            <button type="button" class="button"onclick="closeJobPostModal()">Cancel</button>
-          </div>
-        </form>
-      </div>
-    </div>
-
     {{! profile modal HTML here}}
     <div id='profileModal' class='modal'>
   <div class='modal-content'>


### PR DESCRIPTION
Job post modal html code duplicated in main.handlebars. Removed as redundancy.

Input element for job-description in job post modal changed to textarea in main.handlebars to provide greater visibility and legibility to user. Styling also altered slightly in style.css to apply same rules to textarea as input whilst also taking advantage of adjustable height for user via resize property.

Issue caused by blur/focus event listener differences for jobSalary input element presenting as NaN if user interacts with the field but then leaves it empty fixed. Issue with regular expression formatting (visible only in console) still to be corrected.
